### PR TITLE
Update page titles format

### DIFF
--- a/apps/OpenSign/src/components/Title.js
+++ b/apps/OpenSign/src/components/Title.js
@@ -4,13 +4,18 @@ import { Helmet } from "react-helmet";
 function Title(props) {
   return (
     <Helmet>
-      <title>{`${
-        localStorage.getItem("appTitle") ? localStorage.getItem("appTitle") : ""
-      } - ${props.title}`}</title>
+      <title>{`${props.title} - OpenSign`}</title>
+      {/* <title>
+        {`${localStorage.getItem("appTitle") ? localStorage.getItem("appTitle") : ""} - ${props.title}`}
+      </title> */}
       <meta
         name="description"
-        content={`${localStorage.getItem("appTitle")} - ${props.title}`}
+        content={`${props.title} - OpenSign`}
       />
+      {/* <meta
+        name="description"
+        content={`${localStorage.getItem("appTitle")} - ${props.title}`}
+      /> */}
       <link
         rel="icon"
         type="image/png"

--- a/apps/OpenSign/src/components/Title.js
+++ b/apps/OpenSign/src/components/Title.js
@@ -4,13 +4,13 @@ import { Helmet } from "react-helmet";
 function Title(props) {
   return (
     <Helmet>
-      <title>{`${props.title} - OpenSign`}</title>
+      <title>{`${props.title} - OpenSign™`}</title>
       {/* <title>
         {`${localStorage.getItem("appTitle") ? localStorage.getItem("appTitle") : ""} - ${props.title}`}
       </title> */}
       <meta
         name="description"
-        content={`${props.title} - OpenSign`}
+        content={`${props.title} - OpenSign™`}
       />
       {/* <meta
         name="description"


### PR DESCRIPTION
Fix #85.
Change page titles for all pages from -"contracts - Page Title" to Page Title - OpenSign"
Examples:
Before:
<img width="212" alt="eb842c272428b08858c2b10db7b6fa8" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/d21da40a-f96c-4f95-9c82-f4ace04b6680">
<img width="199" alt="9d32cddfcb01a70ca29700abc8cabf3" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/aa5906c7-4217-49e8-b69c-ccb710d7de19">
<img width="199" alt="6f0977a2a70429722241871b9561435" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/0ba1bfa5-a624-4407-b0c2-d63b4f102fba">

Now:
<img width="247" alt="d0f529cf1e56fdc018acb4043f47f2c" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/e172c782-181a-47ae-95f9-2532145b274e">
<img width="223" alt="36fa5d996a9782e7545933ed1ecb9d1" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/b3bd707a-10ac-47f1-9574-e604000822ec">
<img width="220" alt="fcda886532663c66f7f4a5f6a83a8a5" src="https://github.com/OpenSignLabs/OpenSign/assets/122199576/d3e16a07-b4e7-4b7c-a368-f3d32eb65cbb">

