### PR TITLE
Remove underline that appears on hovering the "Certificate" button

### DIFF
--- a/microfrontends/SignDocuments/src/css/signature.css
+++ b/microfrontends/SignDocuments/src/css/signature.css
@@ -237,6 +237,7 @@
    background: #08bc66;
    border: none !important;
    color: white !important;
+   text-decoration: none !important;
  }
 
  .certificateBtn:hover {


### PR DESCRIPTION
Solves issue #28 