### PR TITLE
#170 - Fix While dragging sign placeholder in mobile view the drawbox…

### DIFF
--- a/microfrontends/SignDocuments/src/Component/component/renderPdf.js
+++ b/microfrontends/SignDocuments/src/Component/component/renderPdf.js
@@ -606,7 +606,7 @@ function RenderPdf({
                             >
                               {" "}
                               <div
-                                onTouchStart={(e) => {
+                                onTouchEnd ={(e) => {
                                   if (!isDragging) {
                                     setTimeout(() => {
                                       e.stopPropagation();
@@ -640,6 +640,7 @@ function RenderPdf({
                                     alt="signimg"
                                     onClick={(e) => {
                                       setSignKey(pos.key);
+                                      console.log("Drag 2");
                                       setIsSignPad(true);
                                       setIsStamp(pos.isStamp);
                                     }}
@@ -692,11 +693,10 @@ function RenderPdf({
                                 }}
                               >
                                 <div
-                                  onTouchStart={(e) => {
+                                  onTouchEnd ={(e) => {
                                     if (!isDragging) {
                                       setTimeout(() => {
                                         setIsSignPad(true);
-
                                         setSignKey(pos.key);
                                         setIsStamp(pos.isStamp);
                                       }, 500);


### PR DESCRIPTION
#170 - While dragging sign placeholder in mobile view the drawbox pops up unexpectedly.

**What was identified:**

- Code was using the **onTouchStart** event to display the Signature Pad. This cause to trigger it even when user drags the placeholder.

**Solution:**
- Use **onTouchEnd** event
- This allows to open signature pad only when user clicks on placeholder. 

Note: This is only for mobile events.

cc @andrew-opensignlabs @nxglabs 