### PR TITLE
fix mongodb_uri in .env.local_dev

### DIFF
--- a/.env.local_dev
+++ b/.env.local_dev
@@ -23,6 +23,7 @@ appName=open_sign_server
 MASTER_KEY=XnAadwKxxByMr
 # Mongodb URI to connect to
 MONGODB_URI=mongodb://host.docker.internal:27017/OpenSignDB
+MONGODB_URI=mongodb://mongo:27017/OpenSignDB
 # Path on which APIs should be mounted. Do not change this. This variable shall be removed & value hardcoded in the source code in coming versions.
 PARSE_MOUNT=/app
 # Set it to the URL from where APIs will be accessible to the NodeJS functions, for local development it should be localhost:3000/api/app (use your local port number instead)


### PR DESCRIPTION
Changed the .env.local_dev file to prevent the OpenSignServer-container to be unable to reach mongo db