### PR TITLE
Fix: draftDocument.js saveFileUsage is not defined.

### DIFF
--- a/apps/OpenSignServer/cloud/customRoute/v1/routes/draftDocument.js
+++ b/apps/OpenSignServer/cloud/customRoute/v1/routes/draftDocument.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { customAPIurl } from '../../../../Utils.js';
+import { customAPIurl, saveFileUsage } from '../../../../Utils.js';
 
 // const randomId = () => Math.floor(1000 + Math.random() * 9000);
 export default async function draftDocument(request, response) {


### PR DESCRIPTION
Fix ReferenceError: saveFileUsage is not defined
src/app/cloud/customRoute/v1/routes/draftDocument.js

Import saveFileUsage from Utils.js