### PR TITLE
Update createDocumentwithCoordinate.js

### DIFF
--- a/apps/OpenSignServer/cloud/customRoute/v1/routes/createDocumentwithCoordinate.js
+++ b/apps/OpenSignServer/cloud/customRoute/v1/routes/createDocumentwithCoordinate.js
@@ -68,7 +68,7 @@ export default async function createDocumentwithCoordinate(request, response) {
   const sendInOrder = request.body.sendInOrder || false;
   // console.log('fileData ', fileData);
   const protocol = customAPIurl();
-  const baseUrl = new URL(process.env.SERVER_URL);
+  const baseUrl = new URL(process.env.PUBLIC_URL);
   const reqToken = request.headers['x-api-token'];
   if (!reqToken) {
     return response.status(400).json({ error: 'Please Provide API Token' });


### PR DESCRIPTION
fix: email and api return url server and not front