### PR TITLE
OpenSignServer-container  | err in sendmailv3 TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"

### DIFF
--- a/apps/OpenSignServer/cloud/parsefunction/sendMailv3.js
+++ b/apps/OpenSignServer/cloud/parsefunction/sendMailv3.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import https from 'https';
+import http from 'http';
 import formData from 'form-data';
 import Mailgun from 'mailgun.js';
 import { updateMailCount } from '../../Utils.js';
@@ -32,7 +32,7 @@ async function sendMailProvider(req) {
       let Pdf = fs.createWriteStream('test.pdf');
       const writeToLocalDisk = () => {
         return new Promise((resolve, reject) => {
-          https.get(req.params.url, async function (response) {
+          http.get(req.params.url, async function (response) {
             response.pipe(Pdf);
             response.on('end', () => resolve('success'));
           });


### PR DESCRIPTION
OpenSignServer-container  | err in sendmailv3 TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"

OpenSignServer-container  |     at new NodeError (node:internal/errors:405:5)
OpenSignServer-container  |     at new ClientRequest (node:_http_client:188:11)
OpenSignServer-container  |     at request (node:https:366:10)
OpenSignServer-container  |     at Object.get (node:https:400:15)
OpenSignServer-container  |     at file:///usr/src/app/cloud/parsefunction/sendMailv3.js:35:17
OpenSignServer-container  |     at new Promise (<anonymous>)
OpenSignServer-container  |     at writeToLocalDisk (file:///usr/src/app/cloud/parsefunction/sendMailv3.js:34:16)
OpenSignServer-container  |     at sendMailProvider (file:///usr/src/app/cloud/parsefunction/sendMailv3.js:42:26)
OpenSignServer-container  |     at sendmailv3 (file:///usr/src/app/cloud/parsefunction/sendMailv3.js:189:39)
OpenSignServer-container  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
OpenSignServer-container  |   code: 'ERR_INVALID_PROTOCOL'
OpenSignServer-container  | }