### PR TITLE
fix: enable mail send feature for non-quick send documents when sendinorder is true & update dependencies 

### DIFF
--- a/apps/OpenSign/package-lock.json
+++ b/apps/OpenSign/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@formkit/auto-animate": "^0.8.2",
-        "@radix-ui/themes": "^2.0.3",
+        "@radix-ui/themes": "^3.0.5",
         "@react-pdf/renderer": "^3.4.4",
         "@reduxjs/toolkit": "^2.2.5",
         "axios": "^1.7.2",
@@ -34,7 +34,7 @@
         "react-helmet": "^6.1.0",
         "react-konva": "^18.2.10",
         "react-modal": "^3.16.1",
-        "react-pdf": "^8.0.2",
+        "react-pdf": "^9.0.0",
         "react-quill": "^2.0.0",
         "react-redux": "^9.1.2",
         "react-rnd": "^10.4.10",
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/@radix-ui/themes": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/themes/-/themes-2.0.3.tgz",
-      "integrity": "sha512-yaXQ8aWT2P1CQ0Xe6YCRD9HXsfMTvKkrIYkrc4aitCzhGTLS0sjtTqKmrxIWMVA+3DIbEuG9K/8aAMRJBhep8g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/themes/-/themes-3.0.5.tgz",
+      "integrity": "sha512-fqIxdxer2tVHtrmuT/Wx793sMKIaJBSZQjFSrkorz6BgOCrijjK6pRRi1qa3Sq78vyjixVXR7kRlieBomUzzzQ==",
       "dependencies": {
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/primitive": "^1.0.1",
@@ -5303,26 +5303,34 @@
         "@radix-ui/react-aspect-ratio": "^1.0.3",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
+        "@radix-ui/react-compose-refs": "^1.0.1",
+        "@radix-ui/react-context": "^1.0.1",
         "@radix-ui/react-context-menu": "^2.1.5",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-direction": "^1.0.1",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-form": "^0.0.3",
         "@radix-ui/react-hover-card": "^1.0.7",
+        "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-popover": "^1.0.7",
         "@radix-ui/react-portal": "^1.0.4",
+        "@radix-ui/react-primitive": "^1.0.3",
+        "@radix-ui/react-progress": "^1.0.3",
         "@radix-ui/react-radio-group": "^1.1.3",
+        "@radix-ui/react-roving-focus": "^1.0.4",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-select": "^2.0.0",
-        "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slider": "^1.1.2",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-toggle-group": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@radix-ui/react-use-callback-ref": "^1.0.1",
+        "@radix-ui/react-use-controllable-state": "^1.0.1",
         "@radix-ui/react-visually-hidden": "^1.0.3",
-        "classnames": "^2.3.2"
+        "classnames": "^2.3.2",
+        "react-remove-scroll-bar": "2.3.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5343,6 +5351,27 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
+    "node_modules/@radix-ui/themes/node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.9.2",
@@ -17411,13 +17440,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/path2d-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
-      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+    "node_modules/path2d": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.0.tgz",
+      "integrity": "sha512-KdPAykQX6kmLSOO6Jpu2KNcCED7CKjmaBNGGNuctOsG0hgYO1OdYQaan6cYXJiG0WmXOwZZPILPBimu5QAIw3A==",
       "optional": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
     "node_modules/pdf-lib": {
@@ -17437,15 +17466,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.11.174",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "version": "4.3.136",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.3.136.tgz",
+      "integrity": "sha512-gzfnt1qc4yA+U46golPGYtU4WM2ssqP2MvFjKga8GEKOrEnzRPrA/9jogLLPYHiA3sGBPJ+p7BdAq+ytmw3jEg==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
         "canvas": "^2.11.2",
-        "path2d-polyfill": "^2.0.1"
+        "path2d": "^0.2.0"
       }
     },
     "node_modules/performance-now": {
@@ -19849,16 +19878,16 @@
       }
     },
     "node_modules/react-pdf": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-8.0.2.tgz",
-      "integrity": "sha512-C0PFC+j9vmEIZ82Iq0c85xUWkgsZTUS05syqOk8NC+7PAanyWlVi/ImYkGQe27zYAlBA6IidRYEt1DAAXKq1Ow==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.0.0.tgz",
+      "integrity": "sha512-J+pza8R2p9oNEOJOHIQJI4o5rFK7ji7bBl2IvsHvz1OOyphvuzVDo5tOJwWAFAbxYauCH3Kt8jOvcMJUOpxYZQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "dequal": "^2.0.3",
         "make-cancellable-promise": "^1.3.1",
         "make-event-props": "^1.6.0",
         "merge-refs": "^1.3.0",
-        "pdfjs-dist": "3.11.174",
+        "pdfjs-dist": "4.3.136",
         "tiny-invariant": "^1.0.0",
         "warning": "^4.0.0"
       },

--- a/apps/OpenSign/package.json
+++ b/apps/OpenSign/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@formkit/auto-animate": "^0.8.2",
-    "@radix-ui/themes": "^2.0.3",
+    "@radix-ui/themes": "^3.0.5",
     "@react-pdf/renderer": "^3.4.4",
     "@reduxjs/toolkit": "^2.2.5",
     "axios": "^1.7.2",
@@ -29,7 +29,7 @@
     "react-helmet": "^6.1.0",
     "react-konva": "^18.2.10",
     "react-modal": "^3.16.1",
-    "react-pdf": "^8.0.2",
+    "react-pdf": "^9.0.0",
     "react-quill": "^2.0.0",
     "react-redux": "^9.1.2",
     "react-rnd": "^10.4.10",

--- a/apps/OpenSign/src/App.js
+++ b/apps/OpenSign/src/App.js
@@ -29,8 +29,7 @@ const Opensigndrive = lazy(() => import("./pages/Opensigndrive"));
 const ManageSign = lazy(() => import("./pages/Managesign"));
 const GenerateToken = lazy(() => import("./pages/GenerateToken"));
 const Webhook = lazy(() => import("./pages/Webhook"));
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
-
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 const Loader = () => {
   return (
     <div

--- a/apps/OpenSign/src/pages/PdfRequestFiles.js
+++ b/apps/OpenSign/src/pages/PdfRequestFiles.js
@@ -790,7 +790,8 @@ function PdfRequestFiles() {
                 const usermail = {
                   Email: pdfDetails?.[0]?.Placeholders[newIndex]?.email || ""
                 };
-                const user = usermail || pdfDetails?.[0]?.Signers[newIndex];
+                const user =
+                  usermail?.Email || pdfDetails?.[0]?.Signers[newIndex];
                 if (sendmail !== "false" && sendInOrder) {
                   const requestBody = pdfDetails?.[0]?.RequestBody;
                   const requestSubject = pdfDetails?.[0]?.RequestSubject;


### PR DESCRIPTION
Previously, the mail send feature was not functioning for non-quick send documents when the sendinorder flag was set to true. This commit resolves the issue by ensuring that the mail send functionality works correctly in this scenario. Now, non-quick send documents will be processed and sent as expected when sendinorder is true.
