### PR TITLE
Edit Docker-Compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   server:
     image: opensign/opensignserver:main


### PR DESCRIPTION
When you install docker via apt on ubuntu 20.04 you usually have docker-compose and not dodcker compose, this small edit should fix it so that the install script also works on legacy docker.