### PR TITLE
Add feature to select different document in template

### DIFF
--- a/apps/OpenSign/src/components/pdf/EditTemplate.js
+++ b/apps/OpenSign/src/components/pdf/EditTemplate.js
@@ -21,7 +21,8 @@ const EditTemplate = ({ template, onSuccess, jwttoken }) => {
     NotifyOnSignatures:
       template?.NotifyOnSignatures !== undefined
         ? template?.NotifyOnSignatures
-        : false
+        : false,
+    BaseDocument: null
   });
   const [isSubscribe, setIsSubscribe] = useState(false);
   useEffect(() => {
@@ -36,6 +37,10 @@ const EditTemplate = ({ template, onSuccess, jwttoken }) => {
   };
   const handleStrInput = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleFileInput = (e) => {
+    setFormData({ ...formData, BaseDocument: e.target.files[0] });
   };
 
   // Define a function to handle form submission
@@ -84,6 +89,17 @@ const EditTemplate = ({ template, onSuccess, jwttoken }) => {
             <div className="op-input op-input-bordered op-input-sm focus:outline-none py-2 font-semibold w-full text-xs">
               {getFileName(template.URL)}
             </div>
+          </div>
+          <div className="mb-[0.35rem]">
+            <label htmlFor="baseDocument" className="text-[13px]">
+              {t("Base Document")}
+            </label>
+            <input
+              type="file"
+              name="BaseDocument"
+              onChange={handleFileInput}
+              className="op-input op-input-bordered op-input-sm focus:outline-none hover:border-base-content w-full text-xs"
+            />
           </div>
           <div className="mb-[0.35rem]">
             <label htmlFor="name" className="text-[13px]">

--- a/apps/OpenSign/src/pages/TemplatePlaceholder.js
+++ b/apps/OpenSign/src/pages/TemplatePlaceholder.js
@@ -139,6 +139,7 @@ const TemplatePlaceholder = () => {
   const [zoomPercent, setZoomPercent] = useState(0);
   const [scale, setScale] = useState(1);
   const [signatureType, setSignatureType] = useState([]);
+  const [baseDocument, setBaseDocument] = useState(null); // P9c02
 
   useEffect(() => {
     fetchTemplate();
@@ -769,6 +770,10 @@ const TemplatePlaceholder = () => {
               ? pdfDetails[0]?.NotifyOnSignatures
               : false
         };
+        if (baseDocument) { // P7c26
+          const base64 = await convertBase64ToFile(baseDocument.name, baseDocument);
+          data.BaseDocument = base64;
+        }
         const updateTemplate = new Parse.Object("contracts_Template");
         updateTemplate.id = templateId;
         for (const key in data) {
@@ -1060,6 +1065,9 @@ const TemplatePlaceholder = () => {
     });
     setPdfDetails(updateTemplate);
     setIsMailSend(false);
+    if (data.BaseDocument) { // P86bd
+      setBaseDocument(data.BaseDocument);
+    }
   };
 
   const handleCloseRoleModal = () => {

--- a/apps/OpenSignServer/cloud/customRoute/v1/routes/CreateDocumentWithTemplate.js
+++ b/apps/OpenSignServer/cloud/customRoute/v1/routes/CreateDocumentWithTemplate.js
@@ -51,6 +51,7 @@ export default async function createDocumentWithTemplate(request, response) {
   const email_body = request.body.email_body;
   const sendInOrder = request.body.sendInOrder || true;
   const TimeToCompleteDays = request.body.timeToCompleteDays || 15;
+  const baseDocument = request.body.baseDocument || null; // Pbbc3
 
   try {
     const reqToken = request.headers['x-api-token'];
@@ -191,8 +192,13 @@ export default async function createDocumentWithTemplate(request, response) {
                 } else {
                   object.set('Signers', templateSigner);
                 }
-                object.set('URL', template.URL);
-                object.set('SignedUrl', template.URL);
+                if (baseDocument) { // P69e9
+                  object.set('URL', baseDocument);
+                  object.set('SignedUrl', baseDocument);
+                } else {
+                  object.set('URL', template.URL);
+                  object.set('SignedUrl', template.URL);
+                }
                 object.set('SentToOthers', true);
                 if (TimeToCompleteDays) {
                   object.set('TimeToCompleteDays', TimeToCompleteDays);

--- a/apps/OpenSignServer/cloud/customRoute/v1/routes/createTemplatewithCoordinate.js
+++ b/apps/OpenSignServer/cloud/customRoute/v1/routes/createTemplatewithCoordinate.js
@@ -20,6 +20,7 @@ export default async function createTemplatewithCoordinate(request, response) {
   const SendinOrder = request.body.sendInOrder || true;
   const isEnableOTP = request.body?.enableOTP === true ? true : false;
   const isTourEnabled = request.body?.enableTour || false;
+  const baseDocument = request.body.baseDocument || null; // P243d
 
   // console.log('fileData ', fileData);
   const protocol = customAPIurl();
@@ -98,6 +99,9 @@ export default async function createTemplatewithCoordinate(request, response) {
         object.set('ExtUserPtr', extUserPtr);
         object.set('IsEnableOTP', isEnableOTP);
         object.set('IsTourEnabled', isTourEnabled);
+        if (baseDocument) { // P335d
+          object.set('BaseDocument', baseDocument);
+        }
         let contact = [];
         if (signers && signers.length > 0) {
           let parseSigners;


### PR DESCRIPTION
Related to #1477

Add functionality to select a different base document in templates.

* **EditTemplate Component**:
  - Add a file input field to allow users to upload a new base document.
  - Update the form submission logic to handle the new base document.
  - Update the state to include the new base document.

* **TemplatePlaceholder Component**:
  - Add logic to handle the new base document when fetching template details.
  - Update the state to include the new base document.
  - Update the `handleSaveTemplate` function to save the new base document.

* **createTemplatewithCoordinate Function**:
  - Add logic to handle the new base document when creating a template.
  - Update the state to include the new base document.

* **createDocumentWithTemplate Function**:
  - Add logic to handle the new base document when creating a document from a template.
  - Update the state to include the new base document.

