### PR TITLE
Migration_Tempelate_ErrorFix

### DIFF
--- a/apps/OpenSignServer/databases/migrations/20240726114557-update_contracts_template_cjs.cjs
+++ b/apps/OpenSignServer/databases/migrations/20240726114557-update_contracts_template_cjs.cjs
@@ -2,7 +2,7 @@
  *
  * @param {Parse} Parse
  */
-exports.up = async Parse => {
+const up = async Parse => {
   const className = 'contracts_Template';
   const schema = new Parse.Schema(className);
   schema.addString('OriginIp');
@@ -13,9 +13,11 @@ exports.up = async Parse => {
  *
  * @param {Parse} Parse
  */
-exports.down = async Parse => {
+const down = async Parse => {
   const className = 'contracts_Template';
   const schema = new Parse.Schema(className);
   schema.deleteField('OriginIp');
   return schema.update();
 };
+
+module.exports = { up, down };


### PR DESCRIPTION
 Export Style Changed
Before: You were using exports.up = ... and exports.down = ... individually.

After: Now you're defining up and down as constants and exporting them together in a single object using module.exports = { up, down };.