### PR TITLE
Build ARM Images

### DIFF
--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -19,12 +19,31 @@ jobs:
         include:
           - image: opensign/opensign
             dockerfile: apps/OpenSign/Dockerhubfile
+            platform: linux/amd64
+            targetarch: ""
+          - image: opensign/opensign
+            dockerfile: apps/OpenSign/Dockerhubfile
+            platform: linux/arm64
+            targetarch: "arm64v8/"
           - image: opensign/opensignserver
             dockerfile: apps/OpenSignServer/Dockerhubfile
+            platform: linux/amd64
+            targetarch: ""
+          - image: opensign/opensignserver
+            dockerfile: apps/OpenSignServer/Dockerhubfile
+            platform: linux/arm64
+            targetarch: "arm64v8/"
     steps:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        if: matrix.platform == 'linux/arm64'
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -49,6 +68,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            TARGETARCH=${{ matrix.targetarch }}

--- a/apps/OpenSign/Dockerhubfile
+++ b/apps/OpenSign/Dockerhubfile
@@ -1,5 +1,7 @@
 # Use an official Node runtime as the base image
-FROM node:22.14.0
+# Use architecture-specific base image for arm64
+ARG TARGETARCH
+FROM ${TARGETARCH}node:22.14.0
 
 # Set the working directory inside the container
 WORKDIR /usr/src/app

--- a/apps/OpenSignServer/Dockerhubfile
+++ b/apps/OpenSignServer/Dockerhubfile
@@ -1,6 +1,6 @@
 # Use an official Node runtime as the base image
-FROM node:22.14.0
-
+ARG TARGETARCH
+FROM ${TARGETARCH}node:22.14.0
 
 # Install LibreOffice for DOCX to PDF conversions
 RUN apt-get update \


### PR DESCRIPTION
Build ARM64 Images.

I've been building ARM64 images using a Gitea action workflow, and the containers work flawlessly. No changes to the project or its dependencies were necessary for this, except changing the Docker image source to the official ARM build of the Node container. I took a stab at updating the GitHub action to accomplish this, but my approach might not be the best. I'm happy to update this to follow your best practices if you don't like my approach.

This would also close #1786.

For transparency, here is the Gitea workflow I've been using:

```
name: Docker Build and Publish
run-name: ${{ gitea.actor }} is runs ci pipeline
on:
  push:
    branches: [arm]

jobs:
  publish:
    strategy:
      matrix:
        include:
          - image: <private registry>/opensign
            dockerfile: apps/OpenSign/Dockerhubfile
          - image: <private registry>/opensignserver
            dockerfile: apps/OpenSignServer/Dockerhubfile
    runs-on: ubuntu-latest
    container:
      image: ghcr.io/catthehacker/ubuntu:act-latest
    steps:
      - uses: https://github.com/actions/checkout@v4
      - name: Set up Docker Buildx
        uses: https://github.com/docker/setup-buildx-action@v3
        env:
          DOCKER_HOST: unix:///var/run/docker.sock
        with:
          config-inline: |
            [registry."<private registry>"]
      - name: Log in to Docker Registry
        uses: https://github.com/docker/login-action@v3
        with:
          registry: <private registry>
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
      - name: Build and push Docker image
        uses: https://github.com/docker/build-push-action@v5
        env:
          DOCKER_HOST: unix:///var/run/docker.sock
        with:
          context: .
          file: ${{ matrix.dockerfile }}
          push: true
          platforms: linux/arm64
          tags: |
            ${{ matrix.image }}:${{ gitea.sha }}
            ${{ matrix.image }}:latest
```