### PR TITLE
Fix duplicate readonly field in opensign.yaml

### DIFF
--- a/docs/docs/API-docs/v1.1/opensign.yaml
+++ b/docs/docs/API-docs/v1.1/opensign.yaml
@@ -1752,7 +1752,6 @@ paths:
           "default": "11-05-2025",
           "min_date": "",
           "max_date": "",
-          "readonly": false,
           "signing_date": false
         }
         ```


### PR DESCRIPTION
Removed duplicate 'readonly' field and ensured proper formatting.