### PR TITLE
[codex] Preserve custom ports in signed local file URLs

### DIFF
--- a/apps/OpenSignServer/cloud/parsefunction/getSignedUrl.js
+++ b/apps/OpenSignServer/cloud/parsefunction/getSignedUrl.js
@@ -125,21 +125,46 @@ export async function getSignedUrl(request) {
   }
 }
 
+export function normalizeLocalFileUrl(fileUrl) {
+  if (!fileUrl) return fileUrl;
+
+  try {
+    const parsedFileUrl = new URL(fileUrl);
+    if (!parsedFileUrl.pathname.includes('/files/')) {
+      return fileUrl;
+    }
+
+    const configuredServerUrl = process.env.SERVER_URL;
+    if (!configuredServerUrl) {
+      return fileUrl;
+    }
+
+    const parsedServerUrl = new URL(configuredServerUrl);
+    parsedFileUrl.protocol = parsedServerUrl.protocol;
+    parsedFileUrl.host = parsedServerUrl.host;
+
+    return parsedFileUrl.toString();
+  } catch (err) {
+    return fileUrl;
+  }
+}
+
 // Function to generate a signed URL with JWT
 export function getSignedLocalUrl(fileUrl, expirationTimeInSeconds) {
   const secretKey = process.env.MASTER_KEY;
   const exp = expirationTimeInSeconds || 200;
   try {
+    const normalizedFileUrl = normalizeLocalFileUrl(fileUrl);
     // Create the payload with the file URL and expiration time
     const payload = {
-      fileUrl,
+      fileUrl: normalizedFileUrl,
       exp: Math.floor(Date.now() / 1000) + exp, // Expiry time in seconds
     };
 
     // Generate the JWT token
     const token = jwt.sign(payload, secretKey);
     // Return the signed URL containing the token
-    return `${fileUrl}?token=${token}`;
+    return `${normalizedFileUrl}?token=${token}`;
   } catch (err) {
     console.log('Err while siging local url', err);
     throw new Error('Invalid or expired token.');
@@ -148,7 +173,7 @@ export function getSignedLocalUrl(fileUrl, expirationTimeInSeconds) {
 
 export function presignedlocalUrl(signedUrl, expirationTimeInSeconds) {
   if (signedUrl?.includes('files')) {
-    const fileUrl = signedUrl.split('?')?.[0];
+    const fileUrl = normalizeLocalFileUrl(signedUrl.split('?')?.[0]);
     const secretKey = process.env.MASTER_KEY;
     const exp = expirationTimeInSeconds || 200;
     try {

--- a/apps/OpenSignServer/spec/Tests.spec.js
+++ b/apps/OpenSignServer/spec/Tests.spec.js
@@ -1,4 +1,10 @@
 import axios from 'axios';
+import {
+  getSignedLocalUrl,
+  normalizeLocalFileUrl,
+  presignedlocalUrl,
+} from '../cloud/parsefunction/getSignedUrl.js';
+
 describe('Parse Server example', () => {
   Parse.User.enableUnsafeCurrentUser();
   it('call function', async () => {
@@ -29,5 +35,52 @@ describe('Parse Server example', () => {
     const { data, headers } = await axios.get('http://localhost:30001/test');
     expect(headers['content-type']).toContain('text/html');
     expect(data).toContain('<title>Parse Server Example</title>');
+  });
+});
+
+describe('local file URL signing', () => {
+  const originalServerUrl = process.env.SERVER_URL;
+  const originalMasterKey = process.env.MASTER_KEY;
+
+  beforeEach(() => {
+    process.env.SERVER_URL = 'https://opensign.example.com:8443/api/app';
+    process.env.MASTER_KEY = 'test-master-key';
+  });
+
+  afterAll(() => {
+    process.env.SERVER_URL = originalServerUrl;
+    process.env.MASTER_KEY = originalMasterKey;
+  });
+
+  it('normalizes local file URLs to the configured server origin', () => {
+    const normalizedUrl = normalizeLocalFileUrl(
+      'https://opensign.example.com/api/app/files/opensign/sample.pdf'
+    );
+
+    expect(normalizedUrl).toBe(
+      'https://opensign.example.com:8443/api/app/files/opensign/sample.pdf'
+    );
+  });
+
+  it('preserves the configured port when signing local file URLs', () => {
+    const signedUrl = getSignedLocalUrl(
+      'https://opensign.example.com/api/app/files/opensign/sample.pdf',
+      200
+    );
+
+    expect(signedUrl).toContain(
+      'https://opensign.example.com:8443/api/app/files/opensign/sample.pdf?token='
+    );
+  });
+
+  it('re-signs existing local URLs with the configured port', () => {
+    const signedUrl = presignedlocalUrl(
+      'https://opensign.example.com/api/app/files/opensign/sample.pdf?token=old-token',
+      200
+    );
+
+    expect(signedUrl).toContain(
+      'https://opensign.example.com:8443/api/app/files/opensign/sample.pdf?token='
+    );
   });
 });


### PR DESCRIPTION
## Summary
- normalize local `/files/...` URLs against `SERVER_URL` before signing them
- preserve the configured host and port for both fresh and already-signed local file URLs
- add regression coverage for custom-port local file URL signing

## Root cause
Local file URLs could be signed using a URL that did not carry the deployment port from `SERVER_URL`. In self-hosted deployments on a custom port, that caused generated file links to fall back to the default origin and break document flows.

## Validation
- direct Node assertions for `normalizeLocalFileUrl`
- direct Node assertions for `getSignedLocalUrl`
- direct Node assertions for `presignedlocalUrl`

## Notes
I could not run the full `npm test` suite in this local Windows environment because the repo's npm/test workflow hit `EPERM` restrictions during process spawn.