### PR TITLE
[codex] Preserve explicit SenderName in request email headers

### DIFF
--- a/apps/OpenSign/src/constant/Utils.js
+++ b/apps/OpenSign/src/constant/Utils.js
@@ -14,6 +14,7 @@ import {
   buildDownloadFilename,
   addPreferenceOpt
 } from "../utils";
+import { resolveMailFromSender } from "./mailUtils";
 
 export const fontsizeArr = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28];
 export const fontColorArr = ["red", "black", "blue", "yellow"];
@@ -3971,10 +3972,12 @@ export const sendEmailToSigners = async (
       const senderName =
         pdfDetails?.[0]?.SenderName || pdfDetails?.[0]?.ExtUserPtr?.Name;
 
-      const from =
-        pdfDetails?.[0]?.SenderName || useNameAsSender
-          ? pdfDetails?.[0]?.ExtUserPtr?.Name || ""
-          : senderEmail;
+      const from = resolveMailFromSender({
+        senderName: pdfDetails?.[0]?.SenderName,
+        useNameAsSender,
+        extUserName: pdfDetails?.[0]?.ExtUserPtr?.Name,
+        senderEmail
+      });
 
       const documentName = `${pdfDetails?.[0].Name}`;
       let replaceVar;

--- a/apps/OpenSign/src/constant/mailUtils.js
+++ b/apps/OpenSign/src/constant/mailUtils.js
@@ -1,0 +1,16 @@
+export function resolveMailFromSender({
+  senderName,
+  useNameAsSender,
+  extUserName,
+  senderEmail
+}) {
+  if (senderName) {
+    return senderName;
+  }
+
+  if (useNameAsSender) {
+    return extUserName || "";
+  }
+
+  return senderEmail;
+}

--- a/apps/OpenSign/src/constant/mailUtils.test.js
+++ b/apps/OpenSign/src/constant/mailUtils.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveMailFromSender } from "./mailUtils";
+
+describe("resolveMailFromSender", () => {
+  it("prefers the explicit sender name when present", () => {
+    expect(
+      resolveMailFromSender({
+        senderName: "Contract Team",
+        useNameAsSender: true,
+        extUserName: "Owner Name",
+        senderEmail: "owner@example.com"
+      })
+    ).toBe("Contract Team");
+  });
+
+  it("falls back to the owner name only when UseNameAsSender is enabled", () => {
+    expect(
+      resolveMailFromSender({
+        senderName: "",
+        useNameAsSender: true,
+        extUserName: "Owner Name",
+        senderEmail: "owner@example.com"
+      })
+    ).toBe("Owner Name");
+  });
+
+  it("falls back to the sender email when no sender name should be used", () => {
+    expect(
+      resolveMailFromSender({
+        senderName: "",
+        useNameAsSender: false,
+        extUserName: "Owner Name",
+        senderEmail: "owner@example.com"
+      })
+    ).toBe("owner@example.com");
+  });
+});


### PR DESCRIPTION
Fixes #2168.

## Summary
- preserve the document's explicit `SenderName` when building the outgoing request email `from` field
- extract the sender-selection precedence into a tiny pure helper
- add regression coverage for explicit sender name, owner-name fallback, and email fallback behavior

## Root cause
`sendEmailToSigners` mixed `||` with a ternary expression without grouping. In JavaScript that evaluates as `(SenderName || useNameAsSender) ? ... : ...`, so any truthy `SenderName` still routed to `ExtUserPtr.Name` instead of preserving the explicit sender name stored on the document.

## Validation
- direct Node assertions covering the intended sender precedence
- added a focused Vitest test file for the helper

## Notes
I could not run the Vitest runner end-to-end in this local Windows environment because Vite/esbuild process spawn hit `EPERM`, but the helper behavior was exercised directly with Node assertions.