### PR TITLE
feat: add page navigator to bottom of the page

### DIFF
--- a/apps/OpenSign/src/pages/PdfRequestFiles.jsx
+++ b/apps/OpenSign/src/pages/PdfRequestFiles.jsx
@@ -52,6 +52,7 @@ import {
   convertJpegToPng,
 } from "../constant/Utils";
 import Header from "../components/pdf/PdfHeader";
+import PrevNext from "../components/pdf/PrevNext";
 import RenderPdf from "../components/pdf/RenderPdf";
 import DefaultSignature from "../components/pdf/DefaultSignature";
 import SignerListComponent from "../components/pdf/SignerListComponent";
@@ -2159,6 +2160,13 @@ function PdfRequestFiles(
                           closeWidgetTour={closeTour}
                         />
                       )}
+                    </div>
+                    <div className="flex justify-center py-2">
+                      <PrevNext
+                        pageNumber={pageNumber}
+                        allPages={allPages}
+                        changePage={changePage}
+                      />
                     </div>
                   </div>
                 </div>

--- a/apps/OpenSign/src/pages/PlaceHolderSign.jsx
+++ b/apps/OpenSign/src/pages/PlaceHolderSign.jsx
@@ -9,6 +9,7 @@ import Tour from "../primitives/Tour";
 import { useLocation, useParams } from "react-router";
 import SignerListPlace from "../components/pdf/SignerListPlace";
 import Header from "../components/pdf/PdfHeader";
+import PrevNext from "../components/pdf/PrevNext";
 import ShareButton from "../primitives/ShareButton";
 import {
   pdfNewWidthFun,
@@ -2269,6 +2270,13 @@ function PlaceHolderSign() {
                     handleClosePrefillTour={handleClosePrefillTour}
                   />
                 )}
+              </div>
+              <div className="flex justify-center py-2">
+                <PrevNext
+                  pageNumber={pageNumber}
+                  allPages={allPages}
+                  changePage={changePage}
+                />
               </div>
             </div>
           </div>

--- a/apps/OpenSign/src/pages/SignyourselfPdf.jsx
+++ b/apps/OpenSign/src/pages/SignyourselfPdf.jsx
@@ -44,6 +44,7 @@ import { useParams } from "react-router";
 import Tour from "../primitives/Tour";
 import Signedby from "../components/pdf/Signedby";
 import Header from "../components/pdf/PdfHeader";
+import PrevNext from "../components/pdf/PrevNext";
 import RenderPdf from "../components/pdf/RenderPdf";
 import PlaceholderCopy from "../components/pdf/PlaceholderCopy";
 import DropdownWidgetOption from "../components/pdf/DropdownWidgetOption";
@@ -1514,6 +1515,13 @@ function SignYourSelf() {
                       addPositionOfSignature={addPositionOfSignature}
                     />
                   )}
+                </div>
+                <div className="flex justify-center py-2">
+                  <PrevNext
+                    pageNumber={pageNumber}
+                    allPages={allPages}
+                    changePage={changePage}
+                  />
                 </div>
               </div>
             </div>

--- a/apps/OpenSign/src/pages/TemplatePlaceholder.jsx
+++ b/apps/OpenSign/src/pages/TemplatePlaceholder.jsx
@@ -7,6 +7,7 @@ import WidgetComponent from "../components/pdf/WidgetComponent";
 import Tour from "../primitives/Tour";
 import SignerListPlace from "../components/pdf/SignerListPlace";
 import Header from "../components/pdf/PdfHeader";
+import PrevNext from "../components/pdf/PrevNext";
 import WidgetNameModal from "../components/pdf/WidgetNameModal";
 import {
   copytoData,
@@ -2126,6 +2127,13 @@ const TemplatePlaceholder = () => {
                     handleClosePrefillTour={handleClosePrefillTour}
                   />
                 )}
+              </div>
+              <div className="flex justify-center py-2">
+                <PrevNext
+                  pageNumber={pageNumber}
+                  allPages={allPages}
+                  changePage={changePage}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

This PR addresses issue #2162 by adding the page navigator at the bottom of the relevant page.

## Changes

- Reused the existing page navigation / pagination component
- Added the navigator at the bottom of the page
- Kept the existing navigation logic unchanged
- Improved usability by allowing users to move between pages without scrolling back to the top

## Related Issue

Closes #2162