### PR TITLE
fix: normalize email during user signup

### DIFF
--- a/apps/OpenSignServer/cloud/parsefunction/usersignup.js
+++ b/apps/OpenSignServer/cloud/parsefunction/usersignup.js
@@ -4,10 +4,16 @@ const serverUrl = cloudServerUrl; //process.env.SERVER_URL;
 const APPID = serverAppId;
 const masterKEY = process.env.MASTER_KEY;
 
+function normalizeEmail(email) {
+  return String(email || '')
+    .toLowerCase()
+    .replace(/\s/g, '');
+}
+
 async function saveUser(userDetails) {
-  const normalizedEmail = normalizeEmail(userDetails.email.toLowerCase().replace(/\s/g, ''));
+  const normalizedEmail = normalizeEmail(userDetails.email);
   const userQuery = new Parse.Query(Parse.User);
-  userQuery.equalTo('username', userDetails.email);
+  userQuery.equalTo('username', normalizedEmail);
   const userRes = await userQuery.first({ useMasterKey: true });
 
   if (userRes) {
@@ -29,9 +35,9 @@ async function saveUser(userDetails) {
     return { id: login.objectId, sessionToken: login.sessionToken };
   } else {
     const user = new Parse.User();
-    user.set('username', userDetails.email);
+    user.set('username', normalizedEmail);
     user.set('password', userDetails.password);
-    user.set('email', userDetails?.email?.toLowerCase()?.replace(/\s/g, ''));
+    user.set('email', normalizedEmail);
     user.set('normalizedEmail', normalizedEmail);
 
     if (userDetails?.phone) {


### PR DESCRIPTION
## Summary
- Define the missing `normalizeEmail` helper used by `usersignup`.
- Reuse the normalized email for signup lookup, username, email, and `normalizedEmail` so case/whitespace variants resolve consistently.

## Why
`apps/OpenSignServer/cloud/parsefunction/usersignup.js` currently calls `normalizeEmail(...)` inside `saveUser()`, but the helper is not defined or imported. In the published server image this causes the signup cloud function to fail with a `ReferenceError` before a self-hosted tenant/user can be created.

## Validation
- `node --check apps/OpenSignServer/cloud/parsefunction/usersignup.js`
- `node -e 'import("./cloud/parsefunction/usersignup.js")'` from `apps/OpenSignServer` after `npm ci`
- `npm exec -- prettier --check apps/OpenSignServer/cloud/parsefunction/usersignup.js`

Note: `npm run lint` currently fails before linting this change because the server package uses ESLint 9.39.4 with only `.eslintrc.json`; ESLint 9 requires `eslint.config.*`.
